### PR TITLE
Fix the GitHub release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,7 +99,9 @@ jobs:
           target: ${{ matrix.target }}
           override: true
       - name: Run tests
-        run: CARGO_BUILD_ARGS="--verbose --release --target ${{ matrix.target }} --target-dir ${{ env.TARGET_DIR }}" make build
+        env:
+          CARGO_BUILD_ARGS: --verbose --release --target ${{ matrix.target }} --target-dir ${{ env.TARGET_DIR }}
+        run: make build
       - name: Strip release binary (linux and macos)
         if: matrix.build == 'linux' || matrix.build == 'macos'
         run: strip "target/${{ matrix.target }}/release/librarian"


### PR DESCRIPTION
Fix the GitHub release workflow by moving out the environment variable
into the right place.

Signed-off-by: Jason Rogena <jason@rogena.me>