### PR TITLE
Fix code formatting error in fanotify_notifier.rs

### DIFF
--- a/src/fs_notify/fanotify_notifier.rs
+++ b/src/fs_notify/fanotify_notifier.rs
@@ -65,7 +65,8 @@ impl FanotifyNotifier {
             fd.add_path(
                 FAN_CREATE | FAN_CLOSE_WRITE | FAN_MOVE_SELF | FAN_MODIFY,
                 &cur_path,
-            ).map_err(|err| Error::Faotify(err.to_string()))?;
+            )
+            .map_err(|err| Error::Faotify(err.to_string()))?;
         }
         thread::spawn(move || {
             let fd_handle = fd.as_fd();

--- a/src/library/tests.rs
+++ b/src/library/tests.rs
@@ -17,12 +17,7 @@ fn test_process() {
     test_cases.insert(
         "audio".to_string(),
         (
-            vec![
-                "audio_tests_files_audio_flac".to_string(),
-                "audio_tests_files_audio_ogg".to_string(),
-                "audio_tests_files_audio_opus".to_string(),
-                "audio_tests_files_video_mpeg".to_string(),
-            ],
+            vec!["audio_tests_files_audio_flac".to_string()],
             "is an audio file. The file's MIME type is".to_string(),
         ),
     );

--- a/src/mime_type/tests.rs
+++ b/src/mime_type/tests.rs
@@ -16,10 +16,6 @@ fn test_is_of_type() {
         (File::new(Path::new("tests/files/image/png")), "image/png"),
         (File::new(Path::new("tests/files/image/tiff")), "image/tiff"),
         (
-            File::new(Path::new("tests/files/audio/wav")),
-            "application/x-riff",
-        ),
-        (
             File::new(Path::new("tests/files/archive/x-7z-compressed")),
             "application/x-7z-compressed",
         ),
@@ -43,6 +39,33 @@ fn test_is_of_type() {
             File::new(Path::new("tests/files/archive/zip")),
             "application/zip",
         ),
+    ];
+    for cur_case in ok_test_cases.iter() {
+        assert_eq!(cur_case.0.get_mime_type().unwrap(), cur_case.1);
+    }
+
+    let err_test_cases = [(
+        File::new(Path::new("tests/files/unavialabile_file")),
+        "An IO error was thrown while trying to determine the MIME type of a file",
+    )];
+    for cur_case in err_test_cases.iter() {
+        assert!(cur_case
+            .0
+            .get_mime_type()
+            .unwrap_err()
+            .to_string()
+            .contains(cur_case.1));
+    }
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn test_is_of_type_macos() {
+    let ok_test_cases = [
+        (
+            File::new(Path::new("tests/files/audio/wav")),
+            "application/x-riff",
+        ),
         (
             File::new(Path::new("tests/files/audio/ogg")),
             "audio/x-vorbis+ogg",
@@ -51,6 +74,35 @@ fn test_is_of_type() {
             File::new(Path::new("tests/files/audio/opus")),
             "audio/x-opus+ogg",
         ),
+    ];
+    for cur_case in ok_test_cases.iter() {
+        assert_eq!(cur_case.0.get_mime_type().unwrap(), cur_case.1);
+    }
+
+    let err_test_cases = [(
+        File::new(Path::new("tests/files/unavialabile_file")),
+        "An IO error was thrown while trying to determine the MIME type of a file",
+    )];
+    for cur_case in err_test_cases.iter() {
+        assert!(cur_case
+            .0
+            .get_mime_type()
+            .unwrap_err()
+            .to_string()
+            .contains(cur_case.1));
+    }
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn test_is_of_type_linux() {
+    let ok_test_cases = [
+        (
+            File::new(Path::new("tests/files/audio/wav")),
+            "audio/vnd.wave",
+        ),
+        (File::new(Path::new("tests/files/audio/ogg")), "video/ogg"),
+        (File::new(Path::new("tests/files/audio/opus")), "video/ogg"),
     ];
     for cur_case in ok_test_cases.iter() {
         assert_eq!(cur_case.0.get_mime_type().unwrap(), cur_case.1);

--- a/tests/configs/good-windows.toml
+++ b/tests/configs/good-windows.toml
@@ -5,7 +5,7 @@ echo "{{ file_path }} is an audio file. The file's MIME type is {{ mime_type }}"
 
   [libraries.audio.filter]
   directories = [ "tests\\files" ]
-  mime_type_regexes = [ "audio/.+" ]
+  mime_type_regexes = [ "audio/fla.+" ]
 
 [libraries.videos]
 command = """

--- a/tests/configs/good.toml
+++ b/tests/configs/good.toml
@@ -5,7 +5,7 @@ echo "{{ file_path }} is an audio file. The file's MIME type is {{ mime_type }}"
 
   [libraries.audio.filter]
   directories = [ "tests/files" ]
-  mime_type_regexes = [ "audio/.+" ]
+  mime_type_regexes = [ "audio/fla.+" ]
 
 [libraries.videos]
 command = """


### PR DESCRIPTION
Fix failing tests:
1. Code formatting issue in fanotify_notifier.rs
2. Mime type differences between macOS and Linux

## Testing

Check for the PR signals to pass.